### PR TITLE
Get unit tests passing with crosstalk 1.2.1

### DIFF
--- a/clinDataReview/tests/testthat/test_timeProfileIntervalPlot.R
+++ b/clinDataReview/tests/testthat/test_timeProfileIntervalPlot.R
@@ -176,8 +176,9 @@ test_that("A selection variable is correctly included in the time interval plot"
   expect_length(res$buttons, 1)
   
   # check button values
+  btnScriptTag <- htmltools::tagQuery(res$buttons)$find("script")$selectedTags()
   buttonData <- jsonlite::fromJSON(
-    txt = rapply(res$buttons[[1]], function(x) x, class = "json")
+    txt = as.character(btnScriptTag[[1]]$children)
   )
   expect_equal(object = buttonData$items$value, expected = levels(data$group))
   


### PR DESCRIPTION
[crosstalk v1.2.1](https://github.com/rstudio/crosstalk/pull/146) (soon to be released) includes [this bugfix](https://github.com/rstudio/crosstalk/pull/141), which happens to break this unit test in `{clinDataReview}`. 

The same unit test can be written without such strong assumptions about the markup generated by `{crosstalk}` (via [`htmltools::tagQuery()`](https://rstudio.github.io/htmltools/articles/tagQuery.html)).

I plan on submitting crosstalk 1.2.1 to CRAN by the end of the week. If you could please submit this patch fix to CRAN before then, it'd be much appreciated.